### PR TITLE
chore: avoid onLayout side effects on new arch

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -76,9 +76,7 @@ class Screen(
             val width = r - l
             val height = b - t
 
-            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-                updateScreenSizeFabric(width, height, t)
-            } else {
+            if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
                 updateScreenSizePaper(width, height)
             }
 


### PR DESCRIPTION
Through investigation of the orientation change bug which caused very large layout shifts when orientation changed, we found the culprit for the very large and often incorrect layout shift. This UIManager updateState side-effect trigged inside a onLayout within RNScreen's Screen component caused an in- between commit layout shift. 


We opened an issue to better understand the reason behind the updateScreenSizeFabric: https://github.com/software-mansion/react-native-screens/issues/2933. Although we know part of this exists to handle edge cases of screen sizing when a native header is present which is not something the Discord app relies on.

Further testing this with the Discord app proved that this does not regress any UI elements. It fixes the orientation change layout shift plus makes the app slightly smoother since Screen mounts are no longer triggering this in-between commit layout update. 

We are moving forward with this patch despite us not yet hearing back from RNScreen team.



**BEFORE**
<video width="200px" src="https://github.com/user-attachments/assets/1396f518-357c-4148-870a-8b9cff39ccf6" />


**AFTER**
<video width="200px" src="https://github.com/user-attachments/assets/32a32142-d64d-4a3b-a01b-670bf325c155" />


Note we are ignoring the horizontal layout shift for now which is due to how we manage the width of the chat and channel views dynamically with Reanimated.
