### PR TITLE
Fix modal slide up navigation with synchronous state update

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -204,12 +204,8 @@ RNS_IGNORE_SUPER_CALL_END
     auto newState = react::RNSScreenState{RCTSizeFromCGSize(self.bounds.size), {0, effectiveContentOffsetY}};
 
     _state->updateState(
-        std::move(newState)
-#if REACT_NATIVE_VERSION_MINOR >= 82
-            ,
-        _synchronousShadowStateUpdatesEnabled ? facebook::react::EventQueue::UpdateMode::unstable_Immediate
-                                              : facebook::react::EventQueue::UpdateMode::Asynchronous
-#endif
+        std::move(newState),
+        facebook::react::EventQueue::UpdateMode::unstable_Immediate
     );
 
     // TODO: Requesting layout on every layout is wrong. We should look for a way to get rid of this.


### PR DESCRIPTION
## Summary
- Always use synchronous (immediate) state updates on modal screens, removing the conditional RN version check
- This ensures modal slide-up navigation state is updated synchronously, preventing visual glitches