### PR TITLE
fix(Android): read toolbar insets from rootWindowInsets

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -123,10 +123,19 @@ open class CustomToolbar(
         // 3. edge-to-edge with translucent navigation buttons bar.
         //
         // Additionally we need to gracefully handle possible display cutouts.
+        //
+        // We deliberately omit the `unhandledInsets` argument here so that
+        // `resolveInsetsOrZero` falls back to `View.rootWindowInsets`. The
+        // insets dispatched via `onApplyWindowInsets` can be consumed by an
+        // ancestor view in the host's hierarchy before reaching this nested
+        // toolbar (e.g. `react-native-keyboard-controller`'s
+        // `EdgeToEdgeReactViewGroup`, which can drop `systemBars.top` to 0).
+        // The window-level insets are not subject to that consumption and
+        // match what `react-native-safe-area-context` reports on the JS side.
         val cutoutInsets =
-            resolveInsetsOrZero(WindowInsetsCompat.Type.displayCutout(), unhandledInsets)
+            resolveInsetsOrZero(WindowInsetsCompat.Type.displayCutout())
         val systemBarInsets =
-            resolveInsetsOrZero(WindowInsetsCompat.Type.systemBars(), unhandledInsets)
+            resolveInsetsOrZero(WindowInsetsCompat.Type.systemBars())
 
         // This seems to work fine in all tested configurations, because cutout & system bars overlap
         // only in portrait mode & top inset is controlled separately, therefore we don't count


### PR DESCRIPTION


## Summary

Fixes the Android native-stack header drawing under the status bar in landscape when an ancestor view in the host's hierarchy consumes the dispatched `systemBars` inset before it reaches the toolbar.

## Problem

In landscape on Android, `ScreenStackHeaderConfig`'s header (`CustomToolbar`) renders without enough top padding, so its title/icons collide with the status bar. Portrait looks correct.

At Discord we hit this on every screen using the native header inside a modal-presented nested `Stack.Navigator` (channel settings, friends sub-screens, edit-channel, …). The visual issue was repro'd in landscape-left and landscape-right.

## Root cause

`CustomToolbar.onApplyWindowInsets` reads the `systemBars` and `displayCutout` insets from the dispatched `WindowInsets` argument (passed through `unhandledInsets`). Those dispatched insets can be consumed by an ancestor view in the host application's view tree before reaching this nested toolbar.

In our case, the consumer is [`EdgeToEdgeReactViewGroup`](https://github.com/kirillzyusko/react-native-keyboard-controller) from `react-native-keyboard-controller`, which we install at the root of our RN tree. By the time dispatch reaches the toolbar inside a nested native-stack, `systemBars.top == 0` even though the activity is edge-to-edge and the status bar is visible.

Portrait looked correct only by coincidence: `cutoutInsets.top` happened to equal the status bar height, so `max(cutoutInsets.top, systemBarInsets.top)` came out right. In landscape, the cutout shifts to the side (`left=136` or `right=136`), `cutoutInsets.top` becomes 0, and the consumed `systemBars.top = 0` is exposed — header draws under the bar.

`react-native-safe-area-context` doesn't see this because `SafeAreaProvider` reads from `View.rootWindowInsets`, which is *not* subject to the consumption that happens on dispatch.

## Fix

Drop the explicit `unhandledInsets` argument from the two `resolveInsetsOrZero` calls in `onApplyWindowInsets` so it falls back to the helper's default source: `View.rootWindowInsets`. Window-level insets are not consumed by ancestor views — they're the same source `react-native-safe-area-context` uses on the JS side.

Net diff: +11 / −2, all in `CustomToolbar.kt` (the bulk is a code comment explaining the *why*).

## Verification

On-device, instrumented `onApplyWindowInsets` to log both the dispatched and root values side-by-side (instrumentation kept on the Discord side, not in this PR):

| Rotation | `dispatched.systemBars.top` | `root.systemBars.top` | `cutout.top` | `resolved.top` |
|---|---:|---:|---:|---:|
| rot=0 portrait | 0 | **136** | 136 | 136 |
| rot=1 landscape-left | 0 | **66** | 0 | **66** |
| rot=3 landscape-right | 0 | **66** | 0 | **66** |

`dispatched.systemBars.top` is 0 in every rotation — confirms upstream consumption. `root.systemBars.top` matches what JS sees via `useSafeAreaInsets()`. With the fix, the toolbar pads its top by `root.systemBars.top` in landscape and the header no longer draws under the status bar in either landscape rotation. Edit-channel "Save" button now lands in its expected position.

## Notes

- This is a Discord-fork branch fix, but it's also a candidate for upstreaming — the divergence between dispatched insets and `View.rootWindowInsets` is not Discord-specific and any host application running a consumer of system-bar insets above the native-stack will hit the same bug.
- No behavior change for hosts that *don't* consume the top inset: `unhandledInsets` and `rootWindowInsets` are identical for them.



Asana - https://app.asana.com/1/236888843494340/project/1206936604377537/task/1215172473226602?focus=true


Proof

Before

<img width="855" height="400" alt="Image" src="https://github.com/user-attachments/assets/6191fc94-0b30-4224-9e75-96de3c487265" />

After
<img width="846" height="429" alt="Image" src="https://github.com/user-attachments/assets/1ea9825b-4216-426b-93f8-60be49361f62" />
