### PR TITLE
Add disable*InsetApplication props (port of #4220)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/CustomToolbar.kt
@@ -131,23 +131,21 @@ open class CustomToolbar(
         // This seems to work fine in all tested configurations, because cutout & system bars overlap
         // only in portrait mode & top inset is controlled separately, therefore we don't count
         // any insets twice.
-        val horizontalInsets =
-            InsetsCompat.of(
-                cutoutInsets.left + systemBarInsets.left,
-                0,
-                cutoutInsets.right + systemBarInsets.right,
-                0,
-            )
+        val leftInset = if (config.consumeLeftInset) cutoutInsets.left + systemBarInsets.left else 0
+        val rightInset = if (config.consumeRightInset) cutoutInsets.right + systemBarInsets.right else 0
+        val horizontalInsets = InsetsCompat.of(leftInset, 0, rightInset, 0)
 
-        // We want to handle display cutout always, no matter the HeaderConfig prop values.
-        // If there are no cutout displays, we want to apply the additional padding to
-        // respect the status bar.
+        // We want to handle display cutout, no matter the HeaderConfig prop values, as long as the
+        // respective edge is not opted out. If there are no cutout displays, we want to apply the
+        // additional top padding to respect the status bar. Top and bottom are controlled
+        // independently so that disabling one does not silently drop the other.
+        val bottomInset = if (config.consumeBottomInset) max(cutoutInsets.bottom, 0) else 0
         val verticalInsets =
             InsetsCompat.of(
                 0,
                 max(cutoutInsets.top, if (shouldApplyTopInset) systemBarInsets.top else 0),
                 0,
-                max(cutoutInsets.bottom, 0),
+                bottomInset,
             )
 
         val newInsets = InsetsCompat.add(horizontalInsets, verticalInsets)

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.kt
@@ -22,6 +22,7 @@ import com.facebook.react.views.text.ReactTypefaceUtils
 import com.swmansion.rnscreens.events.HeaderAttachedEvent
 import com.swmansion.rnscreens.events.HeaderDetachedEvent
 import kotlin.math.max
+import kotlin.properties.Delegates
 
 class ScreenStackHeaderConfig(
     context: Context,
@@ -48,6 +49,25 @@ class ScreenStackHeaderConfig(
     private var backButtonInCustomView = false
     private var tintColor = 0
     private var isAttachedToWindow = false
+
+    var consumeLeftInset by Delegates.observable(true) { _, oldValue, newValue ->
+        if (oldValue != newValue && isAttachedToWindow) {
+            toolbar.requestApplyInsets()
+        }
+    }
+
+    var consumeRightInset by Delegates.observable(true) { _, oldValue, newValue ->
+        if (oldValue != newValue && isAttachedToWindow) {
+            toolbar.requestApplyInsets()
+        }
+    }
+
+    var consumeBottomInset by Delegates.observable(true) { _, oldValue, newValue ->
+        if (oldValue != newValue && isAttachedToWindow) {
+            toolbar.requestApplyInsets()
+        }
+    }
+
     private val defaultStartInset: Int
     private val defaultStartInsetWithNavigation: Int
     private val backClickListener =

--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfigViewManager.kt
@@ -165,6 +165,30 @@ class ScreenStackHeaderConfigViewManager :
         logNotAvailable("topInsetEnabled")
     }
 
+    @ReactProp(name = "consumeLeftInset", defaultBoolean = true)
+    override fun setConsumeLeftInset(
+        config: ScreenStackHeaderConfig,
+        consumeLeftInset: Boolean,
+    ) {
+        config.consumeLeftInset = consumeLeftInset
+    }
+
+    @ReactProp(name = "consumeRightInset", defaultBoolean = true)
+    override fun setConsumeRightInset(
+        config: ScreenStackHeaderConfig,
+        consumeRightInset: Boolean,
+    ) {
+        config.consumeRightInset = consumeRightInset
+    }
+
+    @ReactProp(name = "consumeBottomInset", defaultBoolean = true)
+    override fun setConsumeBottomInset(
+        config: ScreenStackHeaderConfig,
+        consumeBottomInset: Boolean,
+    ) {
+        config.consumeBottomInset = consumeBottomInset
+    }
+
     @ReactProp(name = "color", customType = "Color")
     override fun setColor(
         config: ScreenStackHeaderConfig,

--- a/src/components/ScreenStackHeaderConfig.tsx
+++ b/src/components/ScreenStackHeaderConfig.tsx
@@ -25,6 +25,7 @@ import ScreenStackHeaderSubviewNativeComponent, {
 } from '../fabric/ScreenStackHeaderSubviewNativeComponent';
 import { prepareHeaderBarButtonItems } from './helpers/prepareHeaderBarButtonItems';
 import { isHeaderBarButtonsAvailableForCurrentPlatform } from '../utils';
+import { useEdgeInsetApplication } from './contexts/EdgeInsetApplicationContext';
 
 export const ScreenStackHeaderSubview: React.ComponentType<ScreenStackHeaderSubviewNativeProps> =
   ScreenStackHeaderSubviewNativeComponent;
@@ -33,6 +34,13 @@ export const ScreenStackHeaderConfig = React.forwardRef<
   View,
   ScreenStackHeaderConfigProps
 >((props, ref) => {
+  const { consumeLeftInset, consumeRightInset, consumeBottomInset } =
+    useEdgeInsetApplication(
+      props.disableLeftInsetApplication ?? false,
+      props.disableRightInsetApplication ?? false,
+      props.disableBottomInsetApplication ?? false,
+    );
+
   const { headerLeftBarButtonItems, headerRightBarButtonItems } = props;
 
   const preparedHeaderLeftBarButtonItems =
@@ -113,6 +121,9 @@ export const ScreenStackHeaderConfig = React.forwardRef<
     <ScreenStackHeaderConfigNativeComponent
       {...props}
       userInterfaceStyle={props.experimental_userInterfaceStyle}
+      consumeLeftInset={consumeLeftInset}
+      consumeRightInset={consumeRightInset}
+      consumeBottomInset={consumeBottomInset}
       headerLeftBarButtonItems={preparedHeaderLeftBarButtonItems}
       headerRightBarButtonItems={preparedHeaderRightBarButtonItems}
       onPressHeaderBarButtonItem={onPressHeaderBarButtonItem}

--- a/src/components/ScreenStackItem.tsx
+++ b/src/components/ScreenStackItem.tsx
@@ -22,6 +22,10 @@ import { FooterComponent } from './ScreenFooter';
 import { SafeAreaViewProps } from './safe-area/SafeAreaView.types';
 import SafeAreaView from './safe-area/SafeAreaView';
 import { featureFlags } from '../flags';
+import {
+  EdgeInsetApplicationContext,
+  useEdgeInsetApplication,
+} from './contexts/EdgeInsetApplicationContext';
 
 type Props = Omit<
   ScreenProps,
@@ -54,6 +58,12 @@ function ScreenStackItem(
   const screenRefs = React.useContext(RNSScreensRefContext);
 
   React.useImperativeHandle(ref, () => currentScreenRef.current!);
+
+  const { nextContextValue: nextEdgeContextValue } = useEdgeInsetApplication(
+    headerConfig?.disableLeftInsetApplication ?? false,
+    headerConfig?.disableRightInsetApplication ?? false,
+    headerConfig?.disableBottomInsetApplication ?? false,
+  );
 
   const stackPresentationWithDefault = stackPresentation ?? 'push';
   const headerConfigHiddenWithDefault = headerConfig?.hidden ?? false;
@@ -119,18 +129,20 @@ function ScreenStackItem(
 
   const content = (
     <>
-      <DebugContainer
-        contentStyle={contentStyle}
-        style={debugContainerStyle}
-        stackPresentation={stackPresentationWithDefault}>
-        {shouldUseSafeAreaView ? (
-          <SafeAreaView edges={getSafeAreaEdges(headerConfig)}>
-            {children}
-          </SafeAreaView>
-        ) : (
-          children
-        )}
-      </DebugContainer>
+      <EdgeInsetApplicationContext.Provider value={nextEdgeContextValue}>
+        <DebugContainer
+          contentStyle={contentStyle}
+          style={debugContainerStyle}
+          stackPresentation={stackPresentationWithDefault}>
+          {shouldUseSafeAreaView ? (
+            <SafeAreaView edges={getSafeAreaEdges(headerConfig)}>
+              {children}
+            </SafeAreaView>
+          ) : (
+            children
+          )}
+        </DebugContainer>
+      </EdgeInsetApplicationContext.Provider>
       {/**
        * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
        * We don't render it conditionally based on visibility to make it possible to dynamically render a custom `header`

--- a/src/components/contexts/EdgeInsetApplicationContext.ts
+++ b/src/components/contexts/EdgeInsetApplicationContext.ts
@@ -1,0 +1,57 @@
+import * as React from 'react';
+
+/**
+ * Carries the inset-application state down the stack hierarchy for every edge.
+ *
+ * `left/right/bottomDisabled`: these insets are applied per-header (every header spans the
+ * full width and needs the inset on its own edges, and a custom `SafeAreaView` may consume
+ * them for a part of the subtree). The flags therefore only propagate the opt-out down the
+ * subtree: `true` means an ancestor header opted out, so the whole subtree should skip it.
+ * This context does NOT coordinate which header applies these insets — every header applies
+ * them on its own edges unless opted out.
+ */
+export interface EdgeInsetApplicationState {
+  leftDisabled: boolean;
+  rightDisabled: boolean;
+  bottomDisabled: boolean;
+}
+
+const DEFAULT_STATE: EdgeInsetApplicationState = {
+  leftDisabled: false,
+  rightDisabled: false,
+  bottomDisabled: false,
+};
+
+export const EdgeInsetApplicationContext =
+  React.createContext<EdgeInsetApplicationState>(DEFAULT_STATE);
+
+export function useEdgeInsetApplication(
+  disableLeftInsetApplication: boolean,
+  disableRightInsetApplication: boolean,
+  disableBottomInsetApplication: boolean,
+) {
+  const { leftDisabled, rightDisabled, bottomDisabled } = React.useContext(
+    EdgeInsetApplicationContext,
+  );
+
+  // Once disabled anywhere up the chain, an edge stays disabled for the whole subtree.
+  const nextLeftDisabled = leftDisabled || disableLeftInsetApplication;
+  const nextRightDisabled = rightDisabled || disableRightInsetApplication;
+  const nextBottomDisabled = bottomDisabled || disableBottomInsetApplication;
+
+  const nextContextValue = React.useMemo<EdgeInsetApplicationState>(
+    () => ({
+      leftDisabled: nextLeftDisabled,
+      rightDisabled: nextRightDisabled,
+      bottomDisabled: nextBottomDisabled,
+    }),
+    [nextLeftDisabled, nextRightDisabled, nextBottomDisabled],
+  );
+
+  return {
+    consumeLeftInset: !nextLeftDisabled,
+    consumeRightInset: !nextRightDisabled,
+    consumeBottomInset: !nextBottomDisabled,
+    nextContextValue,
+  };
+}

--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -72,6 +72,9 @@ export interface NativeProps extends ViewProps {
   blurEffect?: CT.WithDefault<BlurEffect, 'none'>;
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean;
+  consumeLeftInset?: boolean;
+  consumeRightInset?: boolean;
+  consumeBottomInset?: boolean;
   headerLeftBarButtonItems?: CT.UnsafeMixed[];
   headerRightBarButtonItems?: CT.UnsafeMixed[];
   onPressHeaderBarButtonItem?: CT.DirectEventHandler<OnPressHeaderBarButtonItemEvent>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,11 @@ export { default as SearchBar } from './components/SearchBar';
 export { default as ScreenContainer } from './components/ScreenContainer';
 export { default as ScreenStack } from './components/ScreenStack';
 export { default as ScreenStackItem } from './components/ScreenStackItem';
+export {
+  EdgeInsetApplicationContext,
+  useEdgeInsetApplication,
+} from './components/contexts/EdgeInsetApplicationContext';
+export type { EdgeInsetApplicationState } from './components/contexts/EdgeInsetApplicationContext';
 export { default as FullWindowOverlay } from './components/FullWindowOverlay';
 export { default as ScreenFooter } from './components/ScreenFooter';
 export { default as ScreenContentWrapper } from './components/ScreenContentWrapper';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -822,6 +822,42 @@ export interface ScreenStackHeaderConfigProps extends ViewProps {
    */
   topInsetEnabled?: boolean;
   /**
+   * When set to `true`, disables left inset handling for this header and all headers in its
+   * subtree.
+   *
+   * The opt-out propagates down the subtree: once an ancestor header sets this to `true`,
+   * setting it back to `false` on a descendant header does not re-enable the inset.
+   *
+   * @default false
+   *
+   * @platform android
+   */
+  disableLeftInsetApplication?: boolean | undefined;
+  /**
+   * When set to `true`, disables right inset handling for this header and all headers in its
+   * subtree.
+   *
+   * The opt-out propagates down the subtree: once an ancestor header sets this to `true`,
+   * setting it back to `false` on a descendant header does not re-enable the inset.
+   *
+   * @default false
+   *
+   * @platform android
+   */
+  disableRightInsetApplication?: boolean | undefined;
+  /**
+   * When set to `true`, disables bottom inset handling for this header and all headers in its
+   * subtree.
+   *
+   * The opt-out propagates down the subtree: once an ancestor header sets this to `true`,
+   * setting it back to `false` on a descendant header does not re-enable the inset.
+   *
+   * @default false
+   *
+   * @platform android
+   */
+  disableBottomInsetApplication?: boolean | undefined;
+  /**
    * Boolean indicating whether the navigation bar is translucent.
    */
   translucent?: boolean;
@@ -1158,8 +1194,7 @@ interface SharedHeaderBarButtonItem {
   accessibilityHint?: string;
 }
 
-export interface HeaderBarButtonItemWithAction
-  extends SharedHeaderBarButtonItem {
+export interface HeaderBarButtonItemWithAction extends SharedHeaderBarButtonItem {
   type: 'button';
   onPress: () => void;
   /**


### PR DESCRIPTION
Ports the per-edge header inset opt-out from [software-mansion/react-native-screens#4220](https://github.com/software-mansion/react-native-screens/pull/4220) into our fork.

By default the native header applies window insets on all edges. This adds three props -` disableLeftInsetApplication`, `disableRightInsetApplication`, `disableBottomInsetApplication` . The opt-out propagates down the screen hierarchy via `EdgeInsetApplicationContext` -> once an ancestor opts out an edge, all descendant headers skip it too.

Changes

- `ScreenStackHeaderConfig.kt` - consumeLeft/Right/BottomInset observable properties (default true)
- `ScreenStackHeaderConfigViewManager.kt` - @ReactProp setters for the three new props
- `CustomToolbar.kt` - gate each horizontal/bottom inset on the corresponding `consume*` flag
- `ScreenStackHeaderConfigNativeComponent.ts` - fabric codegen spec additions
- `src/types.tsx` - disableLeft/Right/BottomInsetApplication public prop types
- `src/components/ScreenStackHeaderConfig.tsx` - maps `disable*` props -> `consume*` via `useEdgeInsetApplication`
- `src/components/ScreenStackItem.tsx` - wraps content in EdgeInsetApplicationContext.Provider
- `src/components/contexts/EdgeInsetApplicationContext.ts` - new context + hook

