### PR TITLE
fix: default consume*Inset props to true

### DIFF
--- a/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
+++ b/src/fabric/ScreenStackHeaderConfigNativeComponent.ts
@@ -72,9 +72,9 @@ export interface NativeProps extends ViewProps {
   blurEffect?: CT.WithDefault<BlurEffect, 'none'>;
   // TODO: implement this props on iOS
   topInsetEnabled?: boolean;
-  consumeLeftInset?: boolean;
-  consumeRightInset?: boolean;
-  consumeBottomInset?: boolean;
+  consumeLeftInset?: CT.WithDefault<boolean, true>;
+  consumeRightInset?: CT.WithDefault<boolean, true>;
+  consumeBottomInset?: CT.WithDefault<boolean, true>;
   headerLeftBarButtonItems?: CT.UnsafeMixed[];
   headerRightBarButtonItems?: CT.UnsafeMixed[];
   onPressHeaderBarButtonItem?: CT.DirectEventHandler<OnPressHeaderBarButtonItemEvent>;


### PR DESCRIPTION
Follow-up to #4220 . The `consume*Inset` props on `ScreenStackHeaderConfig` are declared without a `WithDefault`, so Fabric codegen defaults them to `false`, while the Android native view manager (`ScreenStackHeaderConfig.kt`) defaults them to `true` (`Delegates.observable(true)`).

under prop-update reconciliation (`enablePropsUpdateReconciliationAndroid`) a prop equal to the codegen default is ommited on initial mount, so a `disable*InsetApplication` opt-out is dropped 

